### PR TITLE
main Native_function_invocation

### DIFF
--- a/templates/.php_cs.dist
+++ b/templates/.php_cs.dist
@@ -15,6 +15,7 @@ return PhpCsFixer\Config::create()
         '@Symfony' => true,
         'declare_strict_types' => true,
         'final_class' => true,
+        'native_function_invocation' => true
     ])
     ->setRiskyAllowed(true)
     ->setFinder($finder)


### PR DESCRIPTION
native_function_invocation [@Symfony:risky, @PhpCsFixer:risky]

Add leading \ before function invocation to speed up resolving.

Risky rule: risky when any of the functions are overridden.